### PR TITLE
Proposal: lower noisy log from warn to info

### DIFF
--- a/contents/derived/2025-02-12-known-issues-derived-daily-statitistics.md
+++ b/contents/derived/2025-02-12-known-issues-derived-daily-statitistics.md
@@ -1,6 +1,6 @@
 ---
 date: 2025-02-12T00:00:00Z
-severity: warning
+severity: info
 entries: derived-era5-single-levels-daily-statistics,derived-era5-pressure-levels-daily-statistics,derived-era5-land-daily-statistics
 live: true
 ---


### PR DESCRIPTION
Current status in production:

![Screenshot 2025-05-28 alle 12 54 31](https://github.com/user-attachments/assets/c0308114-3161-40b7-bc99-cc96e20e011b)

This message is assigned to multiple datasets, but is a bit too noisy on the SERP page.

By lowering the level to "info":

- it disappear from the SERP page (where it's probably not very useful)
- it continue to appear on the dataset page

![Screenshot 2025-05-28 alle 12 54 54](https://github.com/user-attachments/assets/4d5d83fc-53fe-447f-8e08-9cf5c505595e)

![Screenshot 2025-05-28 alle 12 55 02](https://github.com/user-attachments/assets/4d0ea772-5d02-4ca4-ae6f-faebc0221303)

